### PR TITLE
Changed bbox filter to use the polygon geometry operator instead of box

### DIFF
--- a/src/main/groovy/com/spidasoftware/mongodb/filter/FilterToDBQuery.groovy
+++ b/src/main/groovy/com/spidasoftware/mongodb/filter/FilterToDBQuery.groovy
@@ -483,11 +483,16 @@ class FilterToDBQuery implements FilterVisitor, ExpressionVisitor {
     Object visit(BBOX filter, Object extraData) {
         BoundingBox boundingBox = filter.getBounds()
         List bottomLeft = [boundingBox.getMinX(), boundingBox.getMinY()]
-        List topRight = [ boundingBox.getMaxX(), boundingBox.getMaxY()]
-        List box = [bottomLeft, topRight]
-        return new BasicDBObject(filter.getExpression1().accept(this, null), new BasicDBObject('$geoWithin', new BasicDBObject('$box', box)))
+        List bottomRight = [boundingBox.getMaxX(), boundingBox.getMinY()]
+        List topRight = [boundingBox.getMaxX(), boundingBox.getMaxY()]
+        List topLeft = [boundingBox.getMinX(), boundingBox.getMaxY()]
+        List ring = [bottomLeft, bottomRight, topRight, topLeft, bottomLeft]
+        BasicDBObject geometry = new BasicDBObject()
+        geometry.put("type", "Polygon")
+        geometry.put("coordinates", [ring])
+        return new BasicDBObject(filter.getExpression1().accept(this, null), new BasicDBObject('$geoWithin', new BasicDBObject('$geometry', geometry)))
     }
-
+    
     @Override
     Object visit(Beyond filter, Object extraData) {
         throw new UnsupportedOperationException()


### PR DESCRIPTION
The $box operator can only take advantage of 2d geospatial indices, not 2dsphere.

https://docs.mongodb.com/manual/reference/operator/query/box/#behavior