### PR TITLE
Fixed LIKE queries for summaryNote field

### DIFF
--- a/src/test/resources/mapping.json
+++ b/src/test/resources/mapping.json
@@ -120,7 +120,8 @@
         "includeInDefaultQuery": true,
         "attributes": [{
             "name": "value",
-            "stringValue": true
+            "stringValue": true,
+            "subCollectionPath": ""
         }]
     }]
 }, {


### PR DESCRIPTION
Previously, the query path for summaryNotes was being built as "calcLocation.summaryNotes.null" because of the way Groovy handles truthiness for strings.